### PR TITLE
change description for index out of bounds

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,7 +7,8 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
+    //public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
+    public static final String MESSAGE_INDEX_OUT_OF_BOUNDS = "The student index provided is out of bounds";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_INVALID_LAB = "The lab number provided is invalid";
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,7 +7,6 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    //public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_INDEX_OUT_OF_BOUNDS = "The student index provided is out of bounds";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_INVALID_LAB = "The lab number provided is invalid";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -36,7 +36,7 @@ public class DeleteCommand extends Command {
         List<Student> lastShownList = model.getFilteredStudentList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
         }
 
         Student studentToDelete = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -74,7 +74,7 @@ public class EditCommand extends Command {
         List<Student> lastShownList = model.getFilteredStudentList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
         }
 
         Student studentToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/EditLabCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLabCommand.java
@@ -122,7 +122,7 @@ public class EditLabCommand extends Command {
         List<Student> lastShownList = model.getFilteredStudentList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
         }
 
         if (!isValidCommand(this)) {

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -33,7 +33,7 @@ public class ViewCommand extends Command {
         List<Student> lastShownList = model.getFilteredStudentList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
         }
 
         Student studentToView = lastShownList.get(targetIndex.getZeroBased());

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_INDEX_OUT_OF_BOUNDS;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.GITHUB_DESC_AMY;
@@ -60,7 +60,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandException(deleteCommand, MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -44,7 +44,7 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class DeleteCommandTest {
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -125,7 +125,7 @@ public class EditCommandTest {
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     /**
@@ -142,7 +142,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
                 new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditLabCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditLabCommandTest.java
@@ -113,7 +113,7 @@ public class EditLabCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         EditLabCommand command = new EditLabCommand(outOfBoundIndex, VALID_LABNUMBER, LabStatus.SUBMITTED);
 
-        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(command, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test
@@ -126,7 +126,7 @@ public class EditLabCommandTest {
 
         EditLabCommand command = new EditLabCommand(outOfBoundIndex, VALID_LABNUMBER, LabStatus.SUBMITTED);
 
-        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(command, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/GradeLabCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GradeLabCommandTest.java
@@ -60,7 +60,7 @@ public class GradeLabCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         GradeLabCommand command = new GradeLabCommand(outOfBoundIndex, VALID_LABNUMBER, VALID_LABMARK);
 
-        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(command, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class GradeLabCommandTest {
 
         GradeLabCommand command = new GradeLabCommand(outOfBoundIndex, VALID_LABNUMBER, VALID_LABMARK);
 
-        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(command, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SubmitLabCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SubmitLabCommandTest.java
@@ -58,7 +58,7 @@ public class SubmitLabCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         SubmitLabCommand command = new SubmitLabCommand(outOfBoundIndex, VALID_LABNUMBER);
 
-        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(command, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class SubmitLabCommandTest {
 
         SubmitLabCommand command = new SubmitLabCommand(outOfBoundIndex, VALID_LABNUMBER);
 
-        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(command, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -46,7 +46,7 @@ public class ViewCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         ViewCommand viewCommand = new ViewCommand(outOfBoundIndex);
 
-        assertCommandFailure(viewCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(viewCommand, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
 
     }
 
@@ -75,7 +75,7 @@ public class ViewCommandTest {
 
         ViewCommand viewCommand = new ViewCommand(outOfBoundIndex);
 
-        assertCommandFailure(viewCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+        assertCommandFailure(viewCommand, model, Messages.MESSAGE_INDEX_OUT_OF_BOUNDS);
     }
 
     @Test


### PR DESCRIPTION
Realised the original message only comes out when the index is out of bounds. 

Simply changed the error message and message naming.